### PR TITLE
change racially tinged noun and adjective

### DIFF
--- a/adjectives.txt
+++ b/adjectives.txt
@@ -35,7 +35,7 @@ pumped
 elderly
 whole
 aromatic
-dark
+darling
 kind
 demonic
 ritzy

--- a/nouns.txt
+++ b/nouns.txt
@@ -329,7 +329,7 @@ run
 pull
 cellar
 blade
-slope
+sloth
 answer
 toad
 metal


### PR DESCRIPTION
Some folks on my team have noted that `slope` is a racial epithet, and adding `dark` as an adjective to certain nouns just gives the phrase can just come out wrong. Might as well change them to things more innocuous.